### PR TITLE
Temporarily connect to personal hotspot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sign-firmware"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sign-firmware"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Jack Hogan <jackhogan11@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/net.rs
+++ b/src/net.rs
@@ -288,7 +288,6 @@ pub async fn self_update(leds: &mut Leds) -> anyhow::Result<()> {
 pub async fn connect_to_network(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyhow::Result<()> {
     let config = Configuration::Client(ClientConfiguration {
         ssid: dotenv!("WIFI_SSID").try_into().unwrap(),
-        password: "".try_into().unwrap(),
         password: dotenv!("WIFI_PASSWORD").try_into().unwrap(),
         auth_method: esp_idf_svc::wifi::AuthMethod::WPA2Personal,
         ..Default::default()

--- a/src/net.rs
+++ b/src/net.rs
@@ -15,7 +15,8 @@ use log::info;
 use palette::rgb::Rgb;
 use url::Url;
 
-use crate::{anyesp, convert_error, EspTlsSocket, Leds};
+// use crate::{anyesp, convert_error, EspTlsSocket, Leds};
+use crate::{convert_error, EspTlsSocket, Leds};
 
 #[derive(Debug, serde::Deserialize)]
 struct GithubResponse {

--- a/src/net.rs
+++ b/src/net.rs
@@ -289,32 +289,33 @@ pub async fn connect_to_network(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyho
     let config = Configuration::Client(ClientConfiguration {
         ssid: dotenv!("WIFI_SSID").try_into().unwrap(),
         password: "".try_into().unwrap(),
-        auth_method: esp_idf_svc::wifi::AuthMethod::WPA2Enterprise,
+        password: dotenv!("WIFI_PASSWORD").try_into().unwrap(),
+        auth_method: esp_idf_svc::wifi::AuthMethod::WPA2Personal,
         ..Default::default()
     });
 
     wifi.set_configuration(&config).map_err(convert_error)?;
 
-    unsafe {
-        use esp_idf_svc::sys::*;
-        anyesp!(esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_STA))?;
-        anyesp!(esp_eap_client_set_identity(
-            dotenv!("WIFI_EMAIL").as_ptr(),
-            dotenv!("WIFI_EMAIL").len() as i32
-        ))?;
-        anyesp!(esp_eap_client_set_username(
-            dotenv!("WIFI_USERNAME").as_ptr(),
-            dotenv!("WIFI_USERNAME").len() as i32
-        ))?;
-        anyesp!(esp_eap_client_set_password(
-            dotenv!("WIFI_PASSWORD").as_ptr(),
-            dotenv!("WIFI_PASSWORD").len() as i32
-        ))?;
-        anyesp!(esp_eap_client_set_ttls_phase2_method(
-            esp_eap_ttls_phase2_types_ESP_EAP_TTLS_PHASE2_MSCHAPV2
-        ))?;
-        anyesp!(esp_wifi_sta_enterprise_enable())?;
-    }
+    // unsafe {
+    //     use esp_idf_svc::sys::*;
+    //     anyesp!(esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_STA))?;
+    //     anyesp!(esp_eap_client_set_identity(
+    //         dotenv!("WIFI_EMAIL").as_ptr(),
+    //         dotenv!("WIFI_EMAIL").len() as i32
+    //     ))?;
+    //     anyesp!(esp_eap_client_set_username(
+    //         dotenv!("WIFI_USERNAME").as_ptr(),
+    //         dotenv!("WIFI_USERNAME").len() as i32
+    //     ))?;
+    //     anyesp!(esp_eap_client_set_password(
+    //         dotenv!("WIFI_PASSWORD").as_ptr(),
+    //         dotenv!("WIFI_PASSWORD").len() as i32
+    //     ))?;
+    //     anyesp!(esp_eap_client_set_ttls_phase2_method(
+    //         esp_eap_ttls_phase2_types_ESP_EAP_TTLS_PHASE2_MSCHAPV2
+    //     ))?;
+    //     anyesp!(esp_wifi_sta_enterprise_enable())?;
+    // }
 
     wifi.start().await.map_err(convert_error)?;
 


### PR DESCRIPTION
The Sign is reliably failing to connect to WiFi in the gallery. We need to connect to something other than PAL.

This code comments out all the WPA2 Enterprise–related code and connects to a simple password-secured network (which will be a hotspot outside the gallery during BURST ✷).

~Need to set a `WIFI_PASSWORD` env var. Expect the builds to fail without it.~ Updated the values in GitHub Actions